### PR TITLE
disable HTML escaping during vCard import

### DIFF
--- a/contacts/javascript/vCard/VCardImporter.js
+++ b/contacts/javascript/vCard/VCardImporter.js
@@ -746,7 +746,7 @@ var VCardImporter = exports.vCardImporter = Class.create({
 	 * @returns {string} The part of the line after the seperator
 	 */
 	_getLineValue: function (line) {
-		line = Foundations.StringUtils.escapeHTML(line);
+		//line = Foundations.StringUtils.escapeHTML(line);
 		return line.substring(line.indexOf(VCard.MARKERS.SEPERATOR) + 1).replace(/\r$/, "");
 	},
 


### PR DESCRIPTION
not sure why they do that? &, < and > should be escaped in UI, which
also seems to happen fine.... it is not very nice to escape that in DB
already.
