### PR TITLE
Add South Sudan & remove Pitcairn

### DIFF
--- a/phonenumberlib/geocoding/idd.json
+++ b/phonenumberlib/geocoding/idd.json
@@ -12,8 +12,8 @@
         "ln": "Unknown Country"
     },
     "211": {
-        "sn": "Unknown Country",
-        "ln": "Unknown Country"
+        "sn": "South Sudan",
+        "ln": "South Sudan"
     },
     "212": {
         "sn": "Morocco",
@@ -892,8 +892,8 @@
         "ln": "Unknown Country"
     },
     "872": {
-        "sn": "Pitcairn",
-        "ln": "Pitcairn"
+        "sn": "Unknown Country",
+        "ln": "Unknown Country"
     },
     "873": {
         "sn": "Unknown Country",


### PR DESCRIPTION
South Sudan was assigned +211 and Pitcairn now uses +64 and no longer
+872
